### PR TITLE
feat: add propagate submodule prompt

### DIFF
--- a/prompts/propogate.md
+++ b/prompts/propogate.md
@@ -1,0 +1,8 @@
+# Propogate
+
+- I have made changes to a submodule
+- Avoid cyclical dependencies
+- Make sure each and every consumer has a PR filed, and merged in order to acknowledge the update.
+- For example, run `git submodule update --remote`. In the root directory, and the `.copilot` directory.
+
+Propogate these changes to all of the consumer repositories.


### PR DESCRIPTION
## Summary
Add propagate submodule prompt to support systematic submodule updates across consumer repositories.

## Changes
- Added `prompts/propogate.md` with submodule propagation workflow documentation

## Impact
- Provides structured approach for submodule updates across the repository ecosystem
- Supports avoiding cyclical dependencies during propagation
- Ensures proper PR workflow for submodule acknowledgment

## Testing
- File added successfully to prompts directory
- Follows existing prompt documentation patterns
- Ready for integration into main branch

This PR is part of a larger submodule propagation workflow to update all consumer repositories systematically.