### PR TITLE
feat: Add GitHub Actions toolset to MCP configuration

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -5,8 +5,14 @@
       "url": "https://mcp.context7.com/mcp"
     },
     "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/x/pull_requests",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
+      "env": {
+        "GITHUB_TOOLSETS": "pull_requests,actions"
+      }
     },
     "playwright": {
       "command": "npx",


### PR DESCRIPTION
# GitHub Actions Toolset Addition

## Summary
Expands GitHub MCP server configuration to include Actions toolset alongside the existing pull_requests toolset, enabling agents to interact with GitHub Actions workflows and runs.

## Changes Made
- **Configuration Approach**: Changed from URL-based restriction (`https://api.githubcopilot.com/mcp/x/pull_requests`) to environment variable approach
- **Server Package**: Updated to use `@modelcontextprotocol/server-github` via npx instead of HTTP endpoint
- **Toolsets**: Added `actions` to `GITHUB_TOOLSETS` environment variable: `pull_requests,actions`
- **Capabilities**: Agents can now interact with both GitHub PRs and GitHub Actions/workflows

## Technical Details
- Uses environment variable `GITHUB_TOOLSETS=pull_requests,actions` for flexible toolset configuration
- Maintains existing PR functionality while adding Actions support
- Follows centralized MCP configuration architecture with `.copilot/.vscode/mcp.json` as source of truth

## Impact
- Enables GitHub Actions workflow management through MCP agents
- Supports workflow triggers, runs, jobs, cancellation, and re-runs
- Maintains backward compatibility with existing PR tools
- Prepares for enhanced CI/CD automation capabilities

## Next Steps
After merge, this change will be propagated through the submodule tree to ensure all consuming repositories benefit from the expanded GitHub toolset.

## Validation
- Configuration tested locally
- Follows Andrew's preference for GitHub MCP server over CLI tools
- Aligns with systematic MCP-driven workflow automation goals