### PR TITLE
feat: Update GitHub MCP server to official version

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -5,13 +5,10 @@
       "url": "https://mcp.context7.com/mcp"
     },
     "github": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-github"
-      ],
-      "env": {
-        "GITHUB_TOOLSETS": "pull_requests,actions"
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "X-MCP-Toolsets": "actions,pull_requests"
       }
     },
     "playwright": {


### PR DESCRIPTION
## Summary

Updates the GitHub MCP server configuration to use the official GitHub MCP server instead of the third-party `@modelcontextprotocol/server-github` package.

## Changes

- **Official Server**: Switch to GitHub's hosted MCP server at `https://api.githubcopilot.com/mcp/`
- **Simplified Configuration**: Remove npx command dependency in favor of HTTP endpoint
- **Toolset Restriction**: Maintain restriction to only `actions` and `pull_requests` toolsets using HTTP headers
- **Header-based Configuration**: Use `X-MCP-Toolsets` header for toolset specification

## Configuration Details

**Before:**
```json
"github": {
  "command": "npx",
  "args": ["-y", "@modelcontextprotocol/server-github"],
  "env": {
    "GITHUB_TOOLSETS": "pull_requests,actions"
  }
}
```

**After:**
```json
"github": {
  "type": "http",
  "url": "https://api.githubcopilot.com/mcp/",
  "headers": {
    "X-MCP-Toolsets": "actions,pull_requests"
  }
}
```

## Benefits

- **Official Support**: Uses GitHub's officially maintained and hosted MCP server
- **No Local Dependencies**: Eliminates need for npx package installation
- **Better Performance**: Hosted solution with better reliability
- **Latest Features**: Access to GitHub's latest MCP server features and updates
- **Simplified Deployment**: No Docker or local runtime requirements

## Compliance

- Maintains Andrew's preference for GitHub MCP server over GitHub CLI
- Follows project requirements for restricting toolset to PR and actions functionality
- Supports centralized MCP configuration propagation architecture